### PR TITLE
.nav-link -> .navlink

### DIFF
--- a/GitHubWhiteNavBar.user.js
+++ b/GitHubWhiteNavBar.user.js
@@ -18,10 +18,10 @@ GM_addStyle('\
 	border-bottom: 1px solid #e5e5e5;\
 }\
 \
-.header-nav-link {\
+.header-navlink {\
 	color: #555;\
 }\
-.header-nav-link:hover {\
+.header-navlink:hover {\
     color: #4078c0;\
 }\
 .header-logo-invertocat {\
@@ -36,13 +36,13 @@ GM_addStyle('\
 .header-logo-wordmark:hover {\
     color: #4078c0;\
 }\
-.header-nav-link:hover .dropdown-caret, .header-nav-link:focus .dropdown-caret {\
+.header-navlink:hover .dropdown-caret, .header-navlink:focus .dropdown-caret {\
     border-top-color: #4078c0;\
 }\
-.header-nav-link:hover .octicon-plus, .header-nav-link:focus .octicon-plus {\
+.header-navlink:hover .octicon-plus, .header-navlink:focus .octicon-plus {\
     border-top-color: #4078c0;\
 }\
-.header-nav-link:hover, .header-nav-link:focus {\
+.header-navlink:hover, .header-navlink:focus {\
     color: #4078c0;\
 }\
 .header .header-search-wrapper {\


### PR DESCRIPTION
As described here, https://github.com/DennisSnijder/MakeGithubGreatAgain/pull/57, GitHub recently changed the `.header-nav-link` to `.header-navlink`